### PR TITLE
feat: pull in repos to allow for contract sharing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM node:11.6.0
 RUN mkdir /truffle
 WORKDIR /truffle
 
+ARG GITHUB_TOKEN
+
 ENV NODE_PATH=/usr/local/lib/node_modules
 
 ENV TRUFFLE_VERSION=4.1.14
@@ -11,6 +13,9 @@ ENV MOCHA_VERSION=5.2.0
 ENV MOCHA_JUNIT_VERSION=1.17.0
 ENV MOCHA_MULTI_VERSION=1.1.7
 ENV DAPP_UTILS_VERSION=1.2.0
+ENV OPENZEPPELIN_VERSION=2.2.0
+ENV ORG_VERSION=https://$GITHUB_TOKEN:x-oauth-basic@github.com/EYBlockchain/organization-api.git
+ENV DICON_VERSION=https://$GITHUB_TOKEN:x-oauth-basic@github.com/EYBlockchain/dicon-api.git
 ENV FAKER_VERSION=git+https://git@github.com/Marak/faker.js.git#d3ce6f1
 
 RUN npm install -g \
@@ -20,6 +25,11 @@ RUN npm install -g \
   mocha-junit-reporter@${MOCHA_JUNIT_VERSION} \
   mocha-multi-reporters@${MOCHA_MULTI_VERSION} \
   dapp-utils@${DAPP_UTILS_VERSION} \
+  openzeppelin-solidity@${OPENZEPPELIN_VERSION} \
+  organization-api@${ORG_VERSION} \
+  dicon-api@${DICON_VERSION} \
   faker@${FAKER_VERSION}
+
+# TODO multi-stage build
 
 ENTRYPOINT ["truffle"]


### PR DESCRIPTION
fairly sure truffle will pull in from node_modules by default. still need to do a lot of testing and decide what a long term approach is.

doing this to test right now `docker build -t truffle:npm --build-arg GITHUB_TOKEN=$GITHUB_TOKEN .` where `$GITHUB_TOKEN` is an env var holding an access token i generated. This is working but getting errors:

```
gyp WARN EACCES user "undefined" does not have permission to access the dev dir "/root/.node-gyp/11.6.0"
gyp WARN EACCES attempting to reinstall using temporary dev dir "/usr/local/lib/node_modules/dicon-api/node_modules/scrypt/.node-gyp"
gyp WARN install got an error, rolling back install
gyp WARN install got an error, rolling back install
gyp ERR! configure error
gyp ERR! stack Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules/dicon-api/node_modules/scrypt/.node-gyp'
gyp ERR! System Linux 4.9.125-linuxkit
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /usr/local/lib/node_modules/dicon-api/node_modules/scrypt
gyp ERR! node -v v11.6.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! scrypt@6.0.3 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the scrypt@6.0.3 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2019-03-15T03_17_14_713Z-debug.log
```